### PR TITLE
Remove body from TERMINATE request

### DIFF
--- a/adaptation_layer/app.py
+++ b/adaptation_layer/app.py
@@ -173,7 +173,7 @@ def terminate_ns(nfvo_id, ns_id):
         driver = manager.get_driver(nfvo_id, database)
         empty_body, headers = driver.terminate_ns(
             ns_id,
-            args={'payload': request.json, 'args': request.args.to_dict()})
+            args={'args': request.args.to_dict()})
         return make_response('', 202, headers)
     except BadRequest as e:
         abort(400, description=e.description)

--- a/adaptation_layer/driver/onap.py
+++ b/adaptation_layer/driver/onap.py
@@ -171,7 +171,7 @@ class ONAP(Driver):
         _url = self._build_url_query(_url, args)
         try:
             emtpy_body, resp_headers = self._exec_post(
-                _url, json=args['payload'], headers={"Content-Type": "application/json"})
+                _url, headers={})
         except ResourceNotFound:
             raise NsNotFound(ns_id=nsId)
         headers = self._build_headers(resp_headers)

--- a/adaptation_layer/tests/onap-api.yaml
+++ b/adaptation_layer/tests/onap-api.yaml
@@ -1,17 +1,17 @@
 openapi: 3.0.0
 
 servers:
-  - description: ns-server
+  - description: ONAP Translation Component
     url: https://github.com/chabimic/NS-InstantiationServer
   - description: Onap driver
     url: https://github.com/TheWall89/adaptation-layer/tree/onap_driver
 
 info:
   description:
-    ONAP ns-server API
-    version with Celery and rabbitMQ with vnf info #and exCpInfo
-  version: "2.0"
-  title: ONAP NS-server API
+    ONAP Translation Component API
+    version with Celery and rabbitMQ with vnf info
+  version: "2.1"
+  title: ONAP Translation Component API
   contact:
     email: michal.grzesik@orange.com
   license:
@@ -26,7 +26,7 @@ tags:
   - name: 'IWL Catalogue API'
     description: API to retrieve the list of service specification and .csar archives
 
-# paths onap nbi & ns-server
+# paths
 paths:
 # get all ns instances info
   '/instances':
@@ -193,11 +193,6 @@ paths:
       summary: terminate a NS Instance with given Id
       description: terminate NS Instance
       operationId: terminateNS
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TerminationTime'
       responses:
         '202':
           description: Accepted
@@ -520,15 +515,6 @@ components:
       required:
         - error
 #
-    TerminationTime:
-      type: object
-      properties:
-        terminationTime:
-          type: string
-          format: date-time
-      required:
-        - terminationTime
-#
     NsInstanceList:
       # description: list of ns instances
       type: array
@@ -776,11 +762,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/createNsId'
-    TerminationTime:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TerminationTime'
   # END REQUEST BODIES
 #
 # # commented

--- a/adaptation_layer/tests/osm-openapi.yaml
+++ b/adaptation_layer/tests/osm-openapi.yaml
@@ -1624,9 +1624,6 @@ paths:
         Occurrence" resource for the request, and the NS instance state becomes
         NOT_INSTANTIATED.
       operationId: terminateNSinstance
-      requestBody:
-        # Request data is not required
-        $ref: '#/components/requestBodies/TerminateNsRequest'
       responses:
         '202':
           description: Accepted
@@ -4468,16 +4465,6 @@ components:
               additionalProperties: true
           additionalProperties: true
       additionalProperties: true
-    TerminateNsRequest:
-      type: object
-      properties:
-        terminationTime:
-          description: |
-            Timestamp indicating the end time of the NS, i.e. the NS will be terminated
-            automatically at this timestamp. Cardinality "0" indicates the NS termination
-            takes place immediately.
-          type: string
-          format: date-time
     ArrayOfNsInstance:
       type: array
       items:
@@ -5147,14 +5134,6 @@ components:
         application/yaml:
           schema:
             $ref: '#/components/schemas/ScaleNsRequest'
-    TerminateNsRequest:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TerminateNsRequest'
-        application/yaml:
-          schema:
-            $ref: '#/components/schemas/TerminateNsRequest'
     CreateNSinstanceContentRequest:
       content:
         application/json:

--- a/adaptation_layer/tests/request_mock.py
+++ b/adaptation_layer/tests/request_mock.py
@@ -27,7 +27,3 @@ mock_ns = {
     "nsName": "test",
     "nsDescription": "test description"
 }
-
-mock_ns_terminate = {
-    "terminationTime": "2017-07-21T17:32:28Z"
-}

--- a/adaptation_layer/tests/test_onap.py
+++ b/adaptation_layer/tests/test_onap.py
@@ -19,7 +19,7 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError, SchemaError
 
 from app import app
-from .request_mock import mock_ns, mock_ns_terminate
+from .request_mock import mock_ns
 from .response_schemas import ns_lcm_op_occ_schema, \
     ns_list_schema, ns_schema, ns_lcm_op_occ_list_schema
 
@@ -99,8 +99,7 @@ class OnapTestCase(unittest.TestCase):
 
     # Check status codes 202, 404, headers and payload for terminate_ns()
     def test_terminate_ns_202(self):
-        res = self.client().post('/nfvo/2/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=202',
-                                 json=mock_ns_terminate)
+        res = self.client().post('/nfvo/2/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=202')
         self.assertEqual(202, res.status_code)
 
         self.assertIn('Location', res.headers)
@@ -108,8 +107,7 @@ class OnapTestCase(unittest.TestCase):
         self.assertTrue(all([validate_url.scheme, validate_url.netloc, validate_url.path]))
 
     def test_terminate_ns_404(self):
-        res = self.client().post('/nfvo/2/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=404',
-                                 json=mock_ns_terminate)
+        res = self.client().post('/nfvo/2/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=404')
         self.assertEqual(404, res.status_code)
 
     # Check status codes 204, 404, headers and payload for delete_ns()

--- a/adaptation_layer/tests/test_osm.py
+++ b/adaptation_layer/tests/test_osm.py
@@ -21,7 +21,7 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError, SchemaError
 
 from app import app
-from .request_mock import mock_ns, mock_ns_scale, mock_ns_terminate
+from .request_mock import mock_ns, mock_ns_scale
 from .response_schemas import ns_lcm_op_occ_schema, ns_list_schema, ns_schema, \
     ns_lcm_op_occ_list_schema
 
@@ -126,22 +126,23 @@ class OSMTestCase(unittest.TestCase):
 
     # Check status codes 202, 401, 404, headers and payload for terminate_ns()
     def test_terminate_ns_202(self):
-        res = self.client().post('/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=202',
-                                 json=mock_ns_terminate)
+        res = self.client().post(
+            '/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=202')
         self.assertEqual(202, res.status_code)
 
         self.assertIn('Location', res.headers)
         validate_url = urlparse(res.headers["Location"])
-        self.assertTrue(all([validate_url.scheme, validate_url.netloc, validate_url.path]))
+        self.assertTrue(
+            all([validate_url.scheme, validate_url.netloc, validate_url.path]))
 
     def test_terminate_ns_404(self):
-        res = self.client().post('/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=404',
-                                 json=mock_ns_terminate)
+        res = self.client().post(
+            '/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=404')
         self.assertEqual(404, res.status_code)
 
     def test_terminate_ns_401(self):
-        res = self.client().post('/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=401',
-                                 json=mock_ns_terminate)
+        res = self.client().post(
+            '/nfvo/1/ns_instances/49ccb6a2-5bcd-4f35-a2cf-7728c54e48b7/terminate?__code=401')
         self.assertEqual(401, res.status_code)
 
     # Check status codes 202, 401, 404, headers and payload for scale_ns()

--- a/openapi/MSO-LO-swagger-resolved.yaml
+++ b/openapi/MSO-LO-swagger-resolved.yaml
@@ -397,8 +397,6 @@ paths:
       description: |
         Terminate NS task.   The POST method terminates a NS instance. This method can only be  used with a NS instance in the INSTANTIATED state. Terminating a NS instance does not delete the NS instance identifier,  but rather transitions the NS into the NOT_INSTANTIATED state.
       operationId: terminateNSinstance
-      produces:
-        - application/json
       parameters:
         - name: nsInstanceId
           in: path
@@ -410,12 +408,6 @@ paths:
           description: Identifier of a Nfvo
           required: true
           type: string
-        - in: body
-          name: body
-          description: ""
-          required: false
-          schema:
-            $ref: '#/definitions/TerminateNsRequest'
       responses:
         "202":
           description: |
@@ -1044,17 +1036,6 @@ definitions:
           $ref: '#/definitions/ErrorResponse_details'
     title: ErrorResponse
     description: Error rappresentation
-  TerminateNsRequest:
-    type: object
-    properties:
-      terminationTime:
-        type: string
-        format: date-time
-        description: |-
-          Timestamp indicating the end time of the NS, i.e. the NS will be terminated
-          automatically at this timestamp. Cardinality '0' indicates the NS termination
-          takes place immediately.
-    title: TerminateNsRequest
   ErrorResponse_details:
     type: object
     properties:


### PR DESCRIPTION
Remove timeout parameter from the TERMINATE request (post).

ONAP unit tests for terminate operations fail at the moment. Please fix ONAP driver to not expect any payload. Thanks.