### PR TITLE
OSM vimAccountId support

### DIFF
--- a/adaptation_layer/driver/osm.py
+++ b/adaptation_layer/driver/osm.py
@@ -200,7 +200,11 @@ class OSM(Driver):
     def create_ns(self, args=None) -> Tuple[Body, Headers]:
         _url = "{0}/nslcm/v1/ns_instances".format(self._base_path)
         _url = self._build_url_query(_url, args)
-        args['payload']['vimAccountId'] = self._select_vim()
+        try:
+            args['payload']['vimAccountId']
+        except (KeyError):
+            logger.info('no vimAccountId set, select first in NFVO')
+            args['payload']['vimAccountId'] = self._select_vim()
         osm_ns, osm_headers = self._request(
             post, _url, json=args['payload'], headers=self._headers)
         # Get location header from OSM

--- a/adaptation_layer/driver/osm.py
+++ b/adaptation_layer/driver/osm.py
@@ -19,22 +19,21 @@ import os
 import re
 from datetime import datetime
 from functools import wraps
-from typing import Dict, Tuple, List
+from typing import Dict, List, Tuple
 from urllib.parse import urlencode
 
-import redis
 import urllib3
 import yaml as YAML
-from requests import ConnectionError, Timeout, TooManyRedirects, URLRequired, \
-    api, HTTPError, get, post, delete
+from requests import ConnectionError, HTTPError, Timeout, TooManyRedirects, URLRequired, api, delete, get, post
 from urllib3.exceptions import InsecureRequestWarning
 
-from adaptation_layer.error_handler import ResourceNotFound, NsNotFound, \
-    VnfNotFound, Unauthorized, ServerError, NsOpNotFound, VnfPkgNotFound, \
-    VimNotFound, NsdNotFound, BadRequest, Forbidden, MethodNotAllowed, \
-    Unprocessable, Conflict, VimNetworkNotFound
+import redis
+from adaptation_layer.error_handler import (BadRequest, Conflict, Forbidden, MethodNotAllowed, NsdNotFound, NsNotFound,
+                                            NsOpNotFound, ResourceNotFound, ServerError, Unauthorized, Unprocessable,
+                                            VimNetworkNotFound, VimNotFound, VnfNotFound, VnfPkgNotFound)
 from adaptation_layer.repository import iwf_repository
-from .interface import Driver, Headers, BodyList, Body
+
+from .interface import Body, BodyList, Driver, Headers
 
 urllib3.disable_warnings(InsecureRequestWarning)
 TESTING = os.getenv('TESTING', 'false').lower()
@@ -266,7 +265,8 @@ class OSM(Driver):
         if additional_params:
             if 'vld' in additional_params:
                 instantiate_payload['vld'] = additional_params['vld']
-                vnf_items = self._force_float_ip(additional_params['vld'], ns_res)
+                vnf_items = self._force_float_ip(
+                    additional_params['vld'], ns_res)
                 self._extend_vnf_add_params(instantiate_payload, vnf_items)
             if 'vnf' in additional_params:
                 mapping = {v: str(i + 1) for i, v in

--- a/adaptation_layer/tests/test_osm.py
+++ b/adaptation_layer/tests/test_osm.py
@@ -50,6 +50,22 @@ class OSMTestCase(unittest.TestCase):
         except (ValidationError, SchemaError) as e:
             self.fail(msg=e.message)
 
+    # Check status codes 201, 401, 404, headers and payload for create_ns()
+    def test_create_ns_201_with_vim(self):
+        mock_ns_vim = mock_ns.copy()
+        mock_ns_vim['vimAccountId'] = '76782dbd-eaa1-48ba-bdc7-a6cbbe5d4e2e'
+        res = self.client().post('/nfvo/1/ns_instances?__code=201', json=mock_ns_vim)
+        self.assertEqual(201, res.status_code)
+
+        self.assertIn('Location', res.headers)
+        validate_url = urlparse(res.headers["Location"])
+        self.assertTrue(all([validate_url.scheme, validate_url.netloc, validate_url.path]))
+
+        try:
+            validate(res.json, ns_schema)
+        except (ValidationError, SchemaError) as e:
+            self.fail(msg=e.message)
+
     def test_create_ns_400(self):
         res = self.client().post('/nfvo/1/ns_instances?__code=400', json=mock_ns)
         self.assertEqual(400, res.status_code)

--- a/openapi/MSO-LO-swagger-resolved.yaml
+++ b/openapi/MSO-LO-swagger-resolved.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   description: 5G-EVE Adaptation Layer API spec.
-  version: '1.4.0'
+  version: '1.5.0'
   title: 5G-EVE Adaptation Layer API
   contact: {}
 host: example.com

--- a/openapi/MSO-LO-swagger-resolved.yaml
+++ b/openapi/MSO-LO-swagger-resolved.yaml
@@ -1613,7 +1613,6 @@ definitions:
     required:
       - nsdId
       - nsName
-      - nsDescription
     properties:
       nsdId:
         type: string

--- a/openapi/MSO-LO-swagger-resolved.yaml
+++ b/openapi/MSO-LO-swagger-resolved.yaml
@@ -1610,6 +1610,10 @@ definitions:
     title: ErrorResponse_details
   NfvoNsInstancesRequest:
     type: object
+    required:
+      - nsdId
+      - nsName
+      - nsDescription
     properties:
       nsdId:
         type: string

--- a/openapi/MSO-LO-swagger-resolved.yaml
+++ b/openapi/MSO-LO-swagger-resolved.yaml
@@ -1621,6 +1621,9 @@ definitions:
         type: string
       nsDescription:
         type: string
+      vimAccountId:
+        type: string
+        format: uuid
     title: NfvoNsInstancesRequest
   NfvoNsInstantiateRequest:
     type: object


### PR DESCRIPTION
Add `vimAccountId` parameter to body for creation of an NS resource. The parameter is not required. If not preset, the OSM driver selects the first vim found from the NFVO.

Other drivers should not be affected by this change.

Ps. OpenAPI version changed to 1.5.0 to prepare the new release.